### PR TITLE
Update php-cs-fixer and lock version

### DIFF
--- a/resources/git-hooks/pre-commit
+++ b/resources/git-hooks/pre-commit
@@ -114,10 +114,13 @@ function validator_php_syntax($hash, $fileName, &$output)
 
 function validator_php_cs($hash, $fileName, &$output)
 {
-    // Use .php_cs config if project has one.
+    $rules = '';
     $configFile = '';
     if (file_exists('.php_cs')) {
-        $configFile = ' --config-file='.escapeshellarg(realpath('.php_cs'));
+        $configFile = ' --config='.escapeshellarg(realpath('.php_cs'));
+    }
+    else {
+        $rules = ' --rules=@Symfony';
     }
 
     $tmpDir = '/tmp/cs-check'.$hash;
@@ -126,7 +129,7 @@ function validator_php_cs($hash, $fileName, &$output)
     run('git cat-file -p '.escapeshellarg($hash).' > '.$tmp);
 
     $return = null;
-    run('php-cs-fixer fix --dry-run --verbose --rules=@Symfony'.$configFile.' '.escapeshellarg($tmp), $currentOutput, $return, 'default', 'default');
+    run('php-cs-fixer fix --dry-run --verbose'.$rules.$configFile.' '.escapeshellarg($tmp), $currentOutput, $return, 'default', 'default');
 
     run('rm -rf '.escapeshellarg($tmpDir));
 

--- a/update
+++ b/update
@@ -30,7 +30,7 @@ fi
 if [ ! -f bin/php-cs-fixer ]
 then
     echo "Installing php-cs-fixer..."
-    curl -L http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar -o bin/php-cs-fixer
+    curl -L https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.9.0/php-cs-fixer.phar -o bin/php-cs-fixer
     chmod +x bin/php-cs-fixer
 fi
 


### PR DESCRIPTION
Fixes deprecated --config-file and mixing of --config and --rules. Also locks the version so it no longer breaks on php-cs-fixer version updates.